### PR TITLE
Refactor block catalogue modal extension for improved handling.

### DIFF
--- a/kraftvaerk.umbraco.blockfilter.Frontend/src/elements/UmbBlockCatalogueModalElementExtension.ts
+++ b/kraftvaerk.umbraco.blockfilter.Frontend/src/elements/UmbBlockCatalogueModalElementExtension.ts
@@ -2,86 +2,189 @@ import { UmbBlockCatalogueModalData, UmbBlockCatalogueModalElement } from "@umbr
 import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from "@umbraco-cms/backoffice/document";
 import { UMB_VARIANT_WORKSPACE_CONTEXT } from "@umbraco-cms/backoffice/workspace";
 import { customElement } from "lit/decorators.js";
-import { BlockfilterClient, OpenAPI } from "../blockfilter-api";
 import { UMB_MODAL_CONTEXT } from "@umbraco-cms/backoffice/modal";
+import { BlockfilterClient, OpenAPI } from "../blockfilter-api";
+
 
 @customElement('umb-block-catalogue-modal-extend')
-export class UmbBlockCatalogueModalElementExtension extends UmbBlockCatalogueModalElement
-{
-  #alias = '';
-  #unique = '';
-  #pageType = '';
+export class UmbBlockCatalogueModalElementExtension extends UmbBlockCatalogueModalElement {
 
+  // Current property alias being edited
+  #alias = '';         
+  
+  // Unique ID for the current page (document)  
+  #unique = '';        
+  
+  // Unique content type key for the current page
+  #pageType = '';      
+
+  // Holds modal data from context
+  #modalData: unknown | null = null;  
+
+  // Ensures handleBlocks() is only executed once
+  #handled = false;                   
+
+  /**
+   * Constructor
+   * Sets up context consumers and observers needed for collecting
+   * page, alias, and modal data before making API requests.
+   */
   constructor() {
     super();
 
-    // grab a few vals we need for the model
-    this.observe(this._manager?.propertyAlias, (value) => {
-      this.#alias = value ?? '';
-    });
+    // Observe Variant Workspace Context.
+    // Used to retrieve the current page's unique ID.
     this.consumeContext(UMB_VARIANT_WORKSPACE_CONTEXT, (workspaceContext) => {
-          this.#unique = workspaceContext?.getUnique() ?? '';      
-        });
 
-    this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (workspaceContext) => {
-        this.observe(workspaceContext?.contentTypeUnique, (value) => {
-          this.#pageType = value ?? '';
-        });
+      // Assign unique ID if available
+      this.#unique = workspaceContext?.getUnique() ?? '';  
+
+      // Try handling blocks if all data is ready
+      this.#tryHandle();                                   
     });
 
-    // modal provides us with data we forward to api
+    // Observe Document Workspace Context.
+    // Used to retrieve the content type unique key for the current document.
+    this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (workspaceContext) => {
+      this.observe(workspaceContext?.contentTypeUnique, (value) => {
+
+        // Store page type unique key        
+        this.#pageType = value ?? ''; 
+
+        // Try handling blocks if all data is ready
+        this.#tryHandle();             
+      });
+    });
+
+    // Observe Modal Context.
+    // Modal context provides the raw block data used by handleBlocks().
+    // We only cache it here and delay processing until other info is ready.
     this.consumeContext(UMB_MODAL_CONTEXT, (modalContext) => {
-      if(modalContext?.data) {
-        this.handleBlocks(modalContext.data);
-      }
+      
+      // Store modal data if present
+      this.#modalData = modalContext?.data ?? null;  
+
+      // Try handling blocks if all data is ready
+      this.#tryHandle();                             
     });
   }
 
+  /**
+   * connectedCallback
+   * Lifecycle method called when the element is attached to the DOM.
+   * Here we can safely observe _manager, which isn't available in the constructor.
+   */
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    // Normally, bypassing a private field is discouraged.
+    // But in this case:
+    // Umbraco’s backoffice APIs don’t expose _manager publicly.
+    // You need to access its observable propertyAlias to extend the modal correctly.
+    // There’s no public API for this yet.
+    // So, using this['_manager'] is a safe and pragmatic escape hatch.
+
+    // Observe property alias
+    // The _manager instance is initialized by the base class around connectedCallback().
+    if (this['_manager']?.propertyAlias) {
+      this.observe(this['_manager'].propertyAlias, (value) => {
+
+        // Store current alias value
+        this.#alias = (value as string) ?? '';  
+
+        // Try handling blocks if all data is ready
+        this.#tryHandle();                      
+      });
+    }
+  }
+
+  /**
+   * #ready
+   * Checks whether all required values (alias, unique, pageType, modalData)
+   * are available before making the API request.
+   */
+  #ready(): boolean {
+    return !!(this.#modalData && this.#alias && this.#unique && this.#pageType);
+  }
+
+  /**
+   * #tryHandle
+   * Simple gatekeeper that ensures handleBlocks() is only called once,
+   * and only when all required data has been collected.
+   */
+  #tryHandle() {
+
+    // Already executed once then skip
+    if (this.#handled) return;        
+
+    // Required data not ready then skip
+    if (!this.#ready()) return;       
+
+    // Mark as handled
+    this.#handled = true;
+
+    // Execute block handling
+    this.handleBlocks(this.#modalData); 
+  }
+
+  /**
+   * handleBlocks
+   * Calls the BlockFilter API with gathered data to rebuild the block catalogue.
+   * Also redefines the clipboard filter to enforce which blocks are allowed.
+   */
   async handleBlocks(data: any) {
+
+    // Combines modal data with alias, page ID, and page type.
+    const requestObject = {
+      ...(data as any),
+      pageId: this.#unique,
+      editingAlias: this.#alias,
+      pageTypeId: this.#pageType
+    };
+
+    // Create client instance.
     const bfc = new BlockfilterClient({
       TOKEN: OpenAPI.TOKEN,
       BASE: OpenAPI.BASE
     });
 
-    const requestObject = {
-          ...data as any, pageId: this.#unique, editingAlias: this.#alias, pageTypeId: this.#pageType
-    } 
-
+    // This returns the allowed block configuration for the current editor context.
     const response = await bfc.v1.postApiV1BlockfilterRemodel({
       requestBody: requestObject
-    });
+    });    
 
+    // Keep any existing clipboard filter before overwriting
     const oldFilter = this.data?.clipboardFilter;
 
+    // Replace this.data with the newly returned block catalogue
     this.data = response as unknown as UmbBlockCatalogueModalData;
 
+    // Extend clipboard filter logic.
+    // Ensures that pasted blocks are allowed based on API-provided allowed keys.
     this.data.clipboardFilter = async (clipboardEntryDetail) => {
-        // Allowed keys from this.data.blocks
-        const allowedKeys = this.data?.blocks.map(b => b.contentElementTypeKey.toLowerCase());
 
-        // Gather all contentTypeKeys from clipboard entry
-        const clipboardKeys = clipboardEntryDetail.values
-            .flatMap(v => v.value?.contentData || [])
-            .map(cd => cd.contentTypeKey?.toLowerCase())
-            .filter(Boolean);
+      // Extract allowed block content type keys
+      const allowedKeys = this.data?.blocks.map(b => b.contentElementTypeKey.toLowerCase());
 
-        // Check: all clipboard contentTypeKeys must be in allowedKeys
-        const allAllowed = clipboardKeys.every(key => allowedKeys?.includes(key));
+      // Gather all contentTypeKeys from clipboard entry
+      const clipboardKeys = clipboardEntryDetail.values
+        .flatMap(v => v.value?.contentData || [])
+        .map(cd => cd.contentTypeKey?.toLowerCase())
+        .filter(Boolean);
 
-        if (!allAllowed) {
-            return false;
-        }
+      // Check that all clipboard entries are allowed
+      const allAllowed = clipboardKeys.every(key => allowedKeys?.includes(key));      
+      if (!allAllowed) return false;
 
-        // Keep old filter behavior if present
-        if (typeof oldFilter === 'function') {
-            return await oldFilter(clipboardEntryDetail);
-        }
-        return true;
+      // Keep old filter behavior if defined
+      if (typeof oldFilter === 'function') return await oldFilter(clipboardEntryDetail);
+      
+      return true;
     };
 
-    // hacky as heck but this will trigger the line
-    // this.#itemManager.setUniques(this.data.blocks.map((block) => block.contentElementTypeKey));
-    // which we need to set the available blocks in the modal since everything else we could manipulate is private.
+    // Trigger base class refresh hack.
+    // This forces the base class to reapply available blocks.
+    // (Private API workaround.)
     this.connectedCallback();
   }
 }


### PR DESCRIPTION
# PR: Make block catalogue remodeling include `editorAlias` (+ reliability & one-shot execution)

## Summary
This refactor ensures the **`editingAlias` (a.k.a. `editorAlias`) is always populated** when posting to the `remodel` endpoint.  
We now wait until all required context is available (modal data, page unique ID, content type key, and the current property’s alias) **before** making the API call—executing it **once** and only once.

---

## Why this change?
Previously, we subscribed to `propertyAlias` in the constructor. In Umbraco’s backoffice, the `_manager` that exposes `propertyAlias` is initialized around `connectedCallback()`, not during construction. As a result:

- `editingAlias` could be missing or empty at the moment we posted to `/api/v1/blockfilter/remodel`.
- The modal sometimes fired the request with incomplete context, causing mismatched filtering rules and inconsistent block lists.

This PR moves alias observation to `connectedCallback()` and introduces a small readiness gate so we **only call the endpoint when all required data is ready**.

---

## What’s changed? (High level)
- **Reliable alias capture**: Observes `this['_manager'].propertyAlias` in `connectedCallback()` when the base class has initialized it.
- **Readiness gate**: Adds `#ready()` + `#tryHandle()` to ensure **all** of `(modalData, alias, unique, pageType)` exist before calling the API.
- **One-shot execution**: Adds `#handled` flag to prevent duplicate requests if multiple observables emit updates.
- **Clearer intent & comments**: Code is documented to explain the private API access and the lifecycle order.
- **Clipboard filter preserved**: Still merges old clipboard filter logic with the new allowlist-based check from the remodeled data.

---

## Behavioral impact
### Before
- API request could be made **without** a valid `editingAlias`, depending on timing.
- Allowed/pasteable blocks might not match the editor’s actual property context.

### After
- API request **always includes `editingAlias`** corresponding to the active editor.
- Allowed/pasteable blocks are consistent with the editor context provided by the API.

---

## API request payload change (example)

**Before (sometimes):**
```json
{
  "pageId": "00000000-0000-0000-0000-000000000000",
  "pageTypeId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
  "editingAlias": ""      // could be empty / missing due to timing
  // ...modal data spread
}
```

**After (stable):**
```json
{
  "pageId": "00000000-0000-0000-0000-000000000000",
  "pageTypeId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
  "editingAlias": "myPropertyAlias",  // now reliably populated
  // ...modal data spread
}
```

> **Key outcome:** As a result of this change, **`editorAlias` is now populated when posting it to remodel**.

---

## Implementation details
- **Lifecycle-safe alias observation**
  - Moves alias observer from constructor to `connectedCallback()`:
    - The base class initializes `_manager` around `connectedCallback()`; observing earlier is unreliable.
  - Uses `this['_manager']?.propertyAlias` (private escape hatch). This is justified because the public API does not provide a supported way to access the current property alias inside the block catalogue modal.

- **Readiness & one-shot logic**
  - `#ready()` returns true when `#modalData`, `#alias`, `#unique`, and `#pageType` are all set.
  - `#tryHandle()` calls `handleBlocks()` exactly once (using `#handled` flag) when ready.

- **Clipboard filter retention**
  - Stores `oldFilter = this.data?.clipboardFilter` and re-applies it after enforcing the API-driven allowlist of content type keys.

- **Forces base refresh**
  - Calls `this.connectedCallback()` at the end as a pragmatic workaround to ensure the base class re-applies available blocks.

---

## Test plan (manual)
1. Open a document with block editors and launch the **Block Catalogue** modal.
2. Select different properties (with different aliases) and re-open the modal.
3. Confirm the **remodel** request body includes:
   - `pageId` (variant unique)
   - `pageTypeId` (document content type unique)
   - `editingAlias` (**non-empty**, matching the active property’s alias)
4. Paste blocks from the clipboard:
   - Blocks whose `contentTypeKey` is **not** in the remodeled list are **rejected** by the filter.
   - Previously allowed cases (according to any existing `clipboardFilter`) still behave correctly when also allowed by the new list.

---

## Edge cases considered
- **Modal opens before alias is known**: Request is deferred until alias is available.
- **Multiple emissions** (e.g., variant/context updates): Guarded by `#handled` to avoid duplicate requests.
- **Missing modal data**: Request never fires; nothing changes.
- **Old clipboard filter undefined**: Fallback to `true` after allowlist check (current behavior preserved).

---

## Risks & mitigations
- **Private API access (`this['_manager']`)**:  
  - _Risk_: Upstream changes to the base class could break access.
  - _Mitigation_: Heavily commented; scoped to read-only observation of `propertyAlias`. If a public API becomes available, we can migrate easily.
- **Double-calling concerns**:  
  - Mitigated by `#handled` flag and readiness check.

---

## Backwards compatibility
- No breaking changes to public interfaces.
- Behavioral change is a **fix**: `editingAlias` is now consistently included.
- Clipboard filtering logic remains backward compatible and enhanced with allowlist enforcement.

---

## Notes for reviewers
- Focus on the lifecycle move (constructor → connected), the gating logic, and the justification for private field access.
- If you know of a public way to read the current editor alias in this modal, please call it out—happy to switch.

---

## Checklist
- [x] Alias observed in `connectedCallback()`  
- [x] Readiness gate (`#ready`/`#tryHandle`)  
- [x] `editingAlias` included in remodel request  
- [x] One-shot execution via `#handled`  
- [x] Clipboard filter preserved and combined with allowlist  
- [x] Comments explaining private API usage and lifecycle timing
