### PR TITLE
Use '.passContextAliasMatches()' for nested hiding elements

### DIFF
--- a/kraftvaerk.umbraco.blockfilter.Frontend/src/elements/UmbBlockCatalogueModalElementExtension.ts
+++ b/kraftvaerk.umbraco.blockfilter.Frontend/src/elements/UmbBlockCatalogueModalElementExtension.ts
@@ -37,14 +37,14 @@ export class UmbBlockCatalogueModalElementExtension extends UmbBlockCatalogueMod
     this.consumeContext(UMB_VARIANT_WORKSPACE_CONTEXT, (variantWorkspaceContext) => {
       UmbBlockCatalogueModalElementExtension.pageId = variantWorkspaceContext?.getUnique() ?? '';
       this.#tryHandle();
-    });
+    }).passContextAliasMatches();
 
     this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (documentWorkspaceContext) => {
       this.observe(documentWorkspaceContext?.contentTypeUnique, (value) => {
         UmbBlockCatalogueModalElementExtension.pageTypeId = value ?? '';
         this.#tryHandle();
       });
-    });
+    }).passContextAliasMatches();
 
     this.consumeContext(UMB_MODAL_CONTEXT, (modalContext) => {
       this.#modalData = modalContext?.data ?? null;


### PR DESCRIPTION
Use '.passContextAliasMatches()' so the hiding elements also works for existing items.

@kasparboelkjeldsen With this the situation described on https://github.com/kraftvaerk/kraftvaerk.umbraco.blockfilter/pull/6#issuecomment-3985454709 is now solved. :)