### PR TITLE
fix(extension): use block owner content type in nested catalogue filt…

### DIFF
--- a/kraftvaerk.umbraco.blockfilter.Extension/src/elements/UmbBlockCatalogueModalElementExtension.ts
+++ b/kraftvaerk.umbraco.blockfilter.Extension/src/elements/UmbBlockCatalogueModalElementExtension.ts
@@ -11,6 +11,7 @@ export class UmbBlockCatalogueModalElementExtension extends UmbBlockCatalogueMod
   #alias = '';
   static pageId = '';
   static pageTypeId = '';
+  #blockOwnerTypeId = '';
   #modalData: unknown | null = null;
   #handled = false;
 
@@ -30,7 +31,12 @@ export class UmbBlockCatalogueModalElementExtension extends UmbBlockCatalogueMod
       this.#keysReadyResolve = resolve;
     });
 
-    this.consumeContext(UMB_BLOCK_WORKSPACE_CONTEXT, () => {
+    this.consumeContext(UMB_BLOCK_WORKSPACE_CONTEXT, (blockWorkspaceContext) => {
+      this.observe(blockWorkspaceContext?.content.contentTypeId, (value) => {
+        this.#blockOwnerTypeId = value ?? '';
+        this.#tryHandle();
+      });
+
       this.#tryHandle();
     });
 
@@ -100,7 +106,12 @@ export class UmbBlockCatalogueModalElementExtension extends UmbBlockCatalogueMod
   }
 
   #ready(): boolean {
-    return !!(this.#modalData && this.#alias && UmbBlockCatalogueModalElementExtension.pageId && UmbBlockCatalogueModalElementExtension.pageTypeId);
+    return !!(
+      this.#modalData &&
+      this.#alias &&
+      UmbBlockCatalogueModalElementExtension.pageId &&
+      (this.#blockOwnerTypeId || UmbBlockCatalogueModalElementExtension.pageTypeId)
+    );
   }
 
   #tryHandle() {
@@ -113,11 +124,13 @@ export class UmbBlockCatalogueModalElementExtension extends UmbBlockCatalogueMod
    * Calls the BlockFilter API and rebuilds the block catalogue with filtered blocks.
    */
   async handleBlocks(data: any) {
+    const ownerTypeId = this.#blockOwnerTypeId || UmbBlockCatalogueModalElementExtension.pageTypeId;
+
     const requestObject = {
       ...(data as any),
       pageId: UmbBlockCatalogueModalElementExtension.pageId,
       editingAlias: this.#alias,
-      pageTypeId: UmbBlockCatalogueModalElementExtension.pageTypeId
+      pageTypeId: ownerTypeId
     };
 
     const bfc = new BlockfilterClient({


### PR DESCRIPTION
## Summary

Fix nested block catalogue filtering by using the parent block content type from `UMB_BLOCK_WORKSPACE_CONTEXT` instead of always using the page document content type.

This fixes cases like nested item pickers where Blockfilter previously received the wrong content type and filtered out valid child blocks.

## Changes

- observe the block owner content type from `UMB_BLOCK_WORKSPACE_CONTEXT`
- prefer the block owner content type over the page document content type when building the remodel request
- update the readiness check to allow either nested block owner type or page type

## Validation

- built `kraftvaerk.umbraco.blockfilter.Extension` successfully with `npm run build`

I added a short clip to clarify where the content is missing:
https://github.com/user-attachments/assets/81b8863f-1364-4958-9c32-ae06f4d5376c



