### PR TITLE
fix(extension): Make block filter label clickable for improved UX

### DIFF
--- a/kraftvaerk.umbraco.blockfilter.Extension/src/elements/BlockFilterSettingsTabView.ts
+++ b/kraftvaerk.umbraco.blockfilter.Extension/src/elements/BlockFilterSettingsTabView.ts
@@ -462,9 +462,18 @@ export class BlockFilterSettingsTabViewElement extends UmbElementMixin(LitElemen
             <div class="block-grid">
                 ${prop.availableBlocks.map(
                     (block) => html`
-                        <label class="block-check">
+                        <label
+                            class="block-check"
+                            @click=${() =>
+                                this.#toggleBlock(
+                                    prop.alias,
+                                    block.key,
+                                    !cfg.enabledBlocks.has(block.key),
+                                )}
+                        >
                             <uui-checkbox
                                 ?checked=${cfg.enabledBlocks.has(block.key)}
+                                @click=${(e: Event) => e.stopPropagation()}
                                 @change=${(e: Event) =>
                                     this.#toggleBlock(
                                         prop.alias,
@@ -601,6 +610,7 @@ export class BlockFilterSettingsTabViewElement extends UmbElementMixin(LitElemen
                 border: 1px solid var(--uui-color-border);
                 border-radius: var(--uui-border-radius);
                 cursor: pointer;
+                user-select: none;
             }
             .block-check:hover {
                 background: var(--uui-color-surface-alt);


### PR DESCRIPTION
Extends the interactive area for block filter toggles from just the checkbox to the entire label. This enhances usability by providing a larger, more intuitive click target.

Includes `stopPropagation` on the checkbox's click event to prevent unintended double-toggling when both the label and checkbox have independent click handlers. Also adds `user-select: none` to the label for a cleaner interaction.